### PR TITLE
Integrated llamaindex agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,37 @@ chat_result = await user_proxy.a_initiate_chat(
 )
 ```
 
-## 3. Prediction
+### 4. LlamaIndex
+
+```python
+import os
+from integry import Integry
+from llama_index.core.tools import FunctionTool, ToolMetadata
+
+user_id = "your user's ID"
+
+# Initialize the client
+integry = Integry(
+    app_key=os.environ.get("INTEGRY_APP_KEY"),
+    app_secret=os.environ.get("INTEGRY_APP_SECRET"),
+)
+
+slack_post_message = await integry.functions.get("slack-post-message", user_id)
+
+llm = OpenAI(model="gpt-4o", temperature=0, api_key=os.environ.get("OPENAI_API_KEY"))
+
+tools = [
+    slack_post_message.get_llamaindex_tool(function, FunctionTool.from_defaults, ToolMetadata, user_id)
+]
+
+agent = ReActAgent.from_tools(tools=tools, llm=llm, verbose=True)
+
+message = "Say hello to my team on slack."
+
+result = agent.chat(message) 
+```
+
+## 5. Prediction
 
 ```python
 import os

--- a/README.md
+++ b/README.md
@@ -172,14 +172,14 @@ slack_post_message = await integry.functions.get("slack-post-message", user_id)
 llm = OpenAI(model="gpt-4o", temperature=0, api_key=os.environ.get("OPENAI_API_KEY"))
 
 tools = [
-    slack_post_message.get_llamaindex_tool(function, FunctionTool.from_defaults, ToolMetadata, user_id)
+    slack_post_message.get_llamaindex_tool(FunctionTool.from_defaults, ToolMetadata, user_id)
 ]
 
 agent = ReActAgent.from_tools(tools=tools, llm=llm, verbose=True)
 
-message = "Say hello to my team on slack."
+task = "Say hello to my team on slack."
 
-result = agent.chat(message) 
+result = await agent.achat(task) 
 ```
 
 ## 5. Prediction

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ chat_result = await user_proxy.a_initiate_chat(
 import os
 from integry import Integry
 from llama_index.core.tools import FunctionTool, ToolMetadata
+from llama_index.llms.openai import OpenAI
 
 user_id = "your user's ID"
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ import os
 from integry import Integry
 from llama_index.core.tools import FunctionTool, ToolMetadata
 from llama_index.llms.openai import OpenAI
+from llama_index.core.agent import ReActAgent
 
 user_id = "your user's ID"
 

--- a/python/README.md
+++ b/python/README.md
@@ -151,6 +151,38 @@ chat_result = await user_proxy.a_initiate_chat(
 )
 ```
 
+### 4. LlamaIndex
+
+```python
+import os
+from integry import Integry
+from llama_index.core.tools import FunctionTool, ToolMetadata
+from llama_index.llms.openai import OpenAI
+from llama_index.core.agent import ReActAgent
+
+user_id = "your user's ID"
+
+# Initialize the client
+integry = Integry(
+    app_key=os.environ.get("INTEGRY_APP_KEY"),
+    app_secret=os.environ.get("INTEGRY_APP_SECRET"),
+)
+
+slack_post_message = await integry.functions.get("slack-post-message", user_id)
+
+llm = OpenAI(model="gpt-4o", temperature=0, api_key=os.environ.get("OPENAI_API_KEY"))
+
+tools = [
+    slack_post_message.get_llamaindex_tool(FunctionTool.from_defaults, ToolMetadata, user_id)
+]
+
+agent = ReActAgent.from_tools(tools=tools, llm=llm, verbose=True)
+
+task = "Say hello to my team on slack."
+
+result = await agent.achat(task) 
+```
+
 # Prediction
 ```python
 import os

--- a/python/src/integry/resources/functions/types.py
+++ b/python/src/integry/resources/functions/types.py
@@ -145,7 +145,7 @@ class Function(BaseModel):
 
         return result
 
-    def register_with_llamaindex_agents(self, tool_from_defaults: Any, user_id: str):
+    def register_with_llamaindex_agents(self, tool_from_defaults: Callable[..., None], user_id: str):
         """
         Register a function with LlamaIndex agents.
 

--- a/python/src/integry/resources/functions/types.py
+++ b/python/src/integry/resources/functions/types.py
@@ -150,7 +150,7 @@ class Function(BaseModel):
         Register a function with LlamaIndex agents.
 
         Args:
-        tool_from_defaults: Function to create a tool for the agent.
+        tool_from_defaults: This should be llamaIndex `FunctionTool.from_defaults` method.
         user_id: The user ID for authentication.
 
         Returns:

--- a/python/src/integry/resources/functions/types.py
+++ b/python/src/integry/resources/functions/types.py
@@ -131,21 +131,22 @@ class Function(BaseModel):
         tool_from_defaults: Callable[..., T],
         tools_metadata: Callable[..., T],
         user_id: str,
+        variables: Optional[dict[str, Any]] = None,
     ) -> T:
         """
-        Returns a llamaIndex tool for the function..
+        Returns a llamaIndex tool for the function.
 
         Args:
             tool_from_defaults: This should be llamaIndex `FunctionTool.from_defaults` method.
-            tools_metadata: LlamaIndex function that generates metadata for the tool.
+            tools_metadata: LlamaIndex's function that generates metadata for the tool.
             user_id: The user ID for authentication.
 
         Returns:
-            llamaindex tool
+            The LlamaIndex tool.
         """
 
         async def execute_function(**kwargs: Dict[str, Any]) -> FunctionCallOutput:
-            callable_function = self._get_callable(user_id=user_id)
+            callable_function = self._get_callable(user_id, variables)
             result = await callable_function(**kwargs)
             return result
 

--- a/python/src/integry/resources/functions/types.py
+++ b/python/src/integry/resources/functions/types.py
@@ -127,8 +127,11 @@ class Function(BaseModel):
     def get_llamaindex_tool[
         T
     ](
-        self, tool_from_defaults: Callable[..., T], tools_metadata: Callable[..., T], user_id: str) -> T:
-        
+        self,
+        tool_from_defaults: Callable[..., T],
+        tools_metadata: Callable[..., T],
+        user_id: str,
+    ) -> T:
         """
         Returns a llamaIndex tool for the function..
 
@@ -147,7 +150,7 @@ class Function(BaseModel):
             return result
 
         function_schema = get_pydantic_model_from_json_schema(
-            json_schema=self.get_json_schema()['parameters'],
+            json_schema=self.get_json_schema()["parameters"],
         )
 
         metadata = tools_metadata(
@@ -156,10 +159,12 @@ class Function(BaseModel):
             fn_schema=function_schema,
         )
 
-        async_fn: Callable[[Dict[str, Any]], Awaitable[Any]] = lambda **kwargs: execute_function(**kwargs)
+        async_fn: Callable[[Dict[str, Any]], Awaitable[Any]] = (
+            lambda **kwargs: execute_function(**kwargs)
+        )
 
         return tool_from_defaults(
-            async_fn = async_fn,
+            async_fn=async_fn,
             tool_metadata=metadata,
         )
 

--- a/python/src/integry/resources/functions/types.py
+++ b/python/src/integry/resources/functions/types.py
@@ -124,17 +124,12 @@ class Function(BaseModel):
         )
         return tool
 
-    def execute_slack_function(self, user_id: str, **kwargs):
+    def execute_function(self, user_id: str, **kwargs):
         """
-        Execute a Slack function dynamically.
-
         Args:
-            slack_function: The Slack function object with name, description, and parameters.
             user_id: The user ID for authentication.
-            **kwargs: Arguments to be validated and passed to the Slack function.
+            **kwargs: Arguments to be validated and passed to the function.
 
-        Returns:
-            Result of the Slack function execution.
         """
         
         if "kwargs" in kwargs:
@@ -145,14 +140,14 @@ class Function(BaseModel):
 
         validated_data = ArgumentSchema(**kwargs)
 
-        slack_function_callable = self._get_sync_callable(user_id=user_id)
-        result = slack_function_callable(**validated_data.model_dump())
+        function_callable = self._get_sync_callable(user_id=user_id)
+        result = function_callable(**validated_data.model_dump())
 
         return result
 
     def register_with_llamaindex_agents(self, tool_from_defaults: Any, user_id: str):
         """
-        Register a Slack function with LlamaIndex agents.
+        Register a function with LlamaIndex agents.
 
         Args:
         tool_from_defaults: Function to create a tool for the agent.
@@ -162,7 +157,7 @@ class Function(BaseModel):
             Registered tool for LlamaIndex agents.
         """
         return tool_from_defaults(
-            fn=lambda **kwargs: self.execute_slack_function(user_id, **kwargs),
+            fn=lambda **kwargs: self.execute_function(user_id, **kwargs),
             name=self.name,
             description=self.description,
         )

--- a/python/src/integry/resources/functions/types.py
+++ b/python/src/integry/resources/functions/types.py
@@ -129,16 +129,16 @@ class Function(BaseModel):
     ](
         self,
         tool_from_defaults: Callable[..., T],
-        tools_metadata: Callable[..., T],
+        tools_metadata: Callable[..., Any],
         user_id: str,
         variables: Optional[dict[str, Any]] = None,
     ) -> T:
         """
-        Returns a llamaIndex tool for the function.
+        Returns a LlamaIndex tool for the function.
 
         Args:
-            tool_from_defaults: This should be llamaIndex `FunctionTool.from_defaults` method.
-            tools_metadata: LlamaIndex's function that generates metadata for the tool.
+            tool_from_defaults: This should be LlamaIndex's `FunctionTool.from_defaults` method.
+            tools_metadata: This should be LlamaIndex's `ToolMetadata` class.
             user_id: The user ID for authentication.
 
         Returns:
@@ -156,7 +156,7 @@ class Function(BaseModel):
         )
 
         return tool_from_defaults(
-            async_fn=self._get_callable(user_id=user_id),
+            async_fn=self._get_callable(user_id=user_id, variables=variables),
             tool_metadata=metadata,
         )
 

--- a/python/src/integry/resources/functions/types.py
+++ b/python/src/integry/resources/functions/types.py
@@ -145,11 +145,6 @@ class Function(BaseModel):
             The LlamaIndex tool.
         """
 
-        async def execute_function(**kwargs: Dict[str, Any]) -> FunctionCallOutput:
-            callable_function = self._get_callable(user_id, variables)
-            result = await callable_function(**kwargs)
-            return result
-
         function_schema = get_pydantic_model_from_json_schema(
             json_schema=self.get_json_schema()["parameters"],
         )
@@ -160,12 +155,8 @@ class Function(BaseModel):
             fn_schema=function_schema,
         )
 
-        async_fn: Callable[[Dict[str, Any]], Awaitable[Any]] = (
-            lambda **kwargs: execute_function(**kwargs)
-        )
-
         return tool_from_defaults(
-            async_fn=async_fn,
+            async_fn=self._get_callable(user_id=user_id),
             tool_metadata=metadata,
         )
 


### PR DESCRIPTION
In `execute_slack_function` Function

1. Added a method to dynamically execute a function using validated arguments.
2. Validates the input arguments against the JSON schema defined in the parameters attribute.
3. Provides structured payload validation using a Pydantic model derived from the JSON schema.
4. Executes the function synchronously using _get_sync_callable, ensuring compatibility with user-specific workflows.

In `register_with_llamaindex_agents` Function

1. Added a method to register a Function using llamaindex.
2. A callable (fn) that wraps execute_slack_function.
3. The name and description attributes of the Function instance.